### PR TITLE
Use wa.me format for WhatsApp links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2024-03-23
+
+### Changed
+- Invitation HTML uses `wa.me` links instead of `api.whatsapp.com`.
+
 ## [2.0.0] - 2024-03-22
 
 ### Breaking Changes

--- a/src/__tests__/invitation/InvitationBuilder.test.js
+++ b/src/__tests__/invitation/InvitationBuilder.test.js
@@ -214,6 +214,7 @@ describe("InvitationBuilder", () => {
       expect(html).toContain("Hello {name}!");
       expect(html).toContain("Jane");
       expect(html).toContain("Bob");
+      expect(html).toContain("https://wa.me/");
     });
 
     it("should generate HTML with formatted phone numbers", () => {

--- a/src/invitation/InvitationBuilder.js
+++ b/src/invitation/InvitationBuilder.js
@@ -290,7 +290,7 @@ export class InvitationBuilder {
                     const phoneMatch = link.href.match(/phone=([^&]+)/);
                     if (phoneMatch && phoneMatch[1]) {
                         const phone = phoneMatch[1];
-                        link.href = \`https://api.whatsapp.com/send/?phone=\${phone}&text=\${encodeMessageForWhatsApp(newMessage)}&type=phone_number&app_absent=0\`;
+                        link.href = \`https://wa.me/\${phone}?text=\${encodeMessageForWhatsApp(newMessage)}\`;
                     }
                 }
             });
@@ -358,8 +358,8 @@ export class InvitationBuilder {
             
             const linksContainer = invitation.querySelector('.whatsapp-links');
             linksContainer.innerHTML = selectedPhones.map(phoneNumber => \`
-                <a href="https://api.whatsapp.com/send/?phone=\${encodeURIComponent(phoneNumber)}&text=\${encodeMessageForWhatsApp(formattedMessage)}&type=phone_number&app_absent=0" 
-                   onclick="markAsOpened(this)" 
+                <a href="https://wa.me/\${encodeURIComponent(phoneNumber)}?text=\${encodeMessageForWhatsApp(formattedMessage)}"
+                   onclick="markAsOpened(this)"
                    class="whatsapp-link"
                    target="_blank">Open WhatsApp (\${formatPhoneNumber(phoneNumber)})</a>
             \`).join('');


### PR DESCRIPTION
## Summary
- switch invitation links from `api.whatsapp.com` to `wa.me`
- document change in CHANGELOG
- test HTML generation for new `wa.me` links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e938f38c8323b1e686bb8fbc07c9