### PR TITLE
Correct similarity threshold

### DIFF
--- a/src/__tests__/contacts/ContactMatcher.test.js
+++ b/src/__tests__/contacts/ContactMatcher.test.js
@@ -99,6 +99,13 @@ describe("ContactMatcher", () => {
       expect(confidence).toBeGreaterThan(0.7);
     });
   });
+
+  describe("isSimilarName", () => {
+    it("should match when similarity is above the threshold", () => {
+      const result = contactMatcher.isSimilarName("abcd", "abxyz");
+      expect(result).toBe(true);
+    });
+  });
 });
 
 // Custom matcher

--- a/src/contacts/ContactMatcher.js
+++ b/src/contacts/ContactMatcher.js
@@ -3,7 +3,8 @@ import Levenshtein from "levenshtein";
 export class ContactMatcher {
   constructor(contacts) {
     this.contacts = contacts;
-    this.similarityThreshold = 0.2; // 50% similarity threshold
+    // Use a 20% similarity threshold for Levenshtein matches
+    this.similarityThreshold = 0.2;
   }
 
   findMatches(name) {


### PR DESCRIPTION
## Summary
- document 20% Levenshtein similarity threshold
- add test confirming the matcher treats 40% similar names as a match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e93f3ba883238e88ce468533d1d9