### PR TITLE
Add Prettier configuration and docs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ src/
   │       └── ContactMatcher.test.js
 ```
 
+### Formatting
+
+Format code using Prettier:
+
+```bash
+npm run format
+```
+
+
 ## Tools
 
 - [levenshtein](https://github.com/gf3/Levenshtein) - String similarity measurement

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node src/index.js",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "levenshtein": "^1.0.5",


### PR DESCRIPTION
## Summary
- configure Prettier via `.prettierrc`
- add a `format` script
- document formatting instructions in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e9464dd8832397bda18480365847