### PR TITLE
Improve phone normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ The links are automatically URL-encoded and include:
 - Phone numbers in international format
 - The formatted message with placeholders replaced
 
+### Phone Number Formats
+
+Numbers may include an international prefix. The parser currently understands Brazilian (55), Estonian (372) and Finnish (358) codes. Ten or eleven digit numbers without a code are assumed to be Brazilian and automatically prefixed with +55.
+
 ### Group Messages
 
 When a line in `names.txt` contains multiple names (separated by the characters specified in `GROUP_SEPARATORS` environment variable, defaulting to `,` and ` e `), the group message will be used. For example:

--- a/src/__tests__/contacts/ContactParser.test.js
+++ b/src/__tests__/contacts/ContactParser.test.js
@@ -43,6 +43,22 @@ END:VCARD`;
         email: "",
       });
     });
+
+    it("should parse international numbers with known country codes", () => {
+      const vcardContent = `BEGIN:VCARD
+VERSION:3.0
+FN:Jane Doe
+TEL:3721234567
+TEL:+358401234567
+END:VCARD`;
+
+      const result = contactParser.parseVCardContent(vcardContent);
+      expect(result).toEqual({
+        name: "Jane Doe",
+        phones: ["+3721234567", "+358401234567"],
+        email: "",
+      });
+    });
   });
 
   describe("loadContactsFromDirectory", () => {

--- a/src/contacts/ContactParser.js
+++ b/src/contacts/ContactParser.js
@@ -14,13 +14,8 @@ export class ContactParser {
     const digits = phone.replace(/\D/g, "");
 
     // Check for known country codes
-    if (digits.startsWith("55")) {
-      return `+${digits}`;
-    }
-    if (digits.startsWith("372")) {
-      return `+${digits}`;
-    }
-    if (digits.startsWith("358")) {
+    const knownCodes = ["55", "372", "358"];
+    if (knownCodes.some((code) => digits.startsWith(code))) {
       return `+${digits}`;
     }
 

--- a/src/invitation/InvitationBuilder.js
+++ b/src/invitation/InvitationBuilder.js
@@ -193,15 +193,20 @@ export class InvitationBuilder {
             // Remove all non-digit characters
             const cleaned = phone.replace(/\D/g, '');
             
-            // Format Brazilian numbers (assuming 55 is the country code)
-            if (cleaned.startsWith('55')) {
-                const countryCode = cleaned.substring(0, 2);
-                const areaCode = cleaned.substring(2, 4);
-                const firstPart = cleaned.substring(4, 9);
-                const secondPart = cleaned.substring(9);
-                return \`\${countryCode} \${areaCode} \${firstPart}-\${secondPart}\`;
+            // Handle known country codes
+            const knownCodes = ["55", "372", "358"];
+            const code = knownCodes.find(c => cleaned.startsWith(c));
+            if (code) {
+                const rest = cleaned.slice(code.length);
+                if (code === "55" && rest.length >= 10) {
+                    const areaCode = rest.substring(0, 2);
+                    const firstPart = rest.substring(2, 7);
+                    const secondPart = rest.substring(7);
+                    return \`\${code} \${areaCode} \${firstPart}-\${secondPart}\`;
+                }
+                return \`\${code} \${rest}\`;
             }
-            
+
             // Default format for other numbers
             return phone;
         }


### PR DESCRIPTION
## Summary
- generalize phone normalization for multiple country codes
- display phone numbers with various codes in generated HTML
- document supported phone formats
- test phone parsing for international numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e954ccd0832384196fbb604f03d3